### PR TITLE
build(deps): upgrade mlflow to 2.10.2

### DIFF
--- a/requirements-mlflow.txt
+++ b/requirements-mlflow.txt
@@ -30,7 +30,6 @@ charset-normalizer==2.0.12
     # via requests
 click==8.1.3
     # via
-    #   databricks-cli
     #   flask
     #   mlflow
 cloudpickle==2.1.0
@@ -41,8 +40,6 @@ cryptography==42.0.4
     # via -r requirements-mlflow.in
 cycler==0.11.0
     # via matplotlib
-databricks-cli==0.17.0
-    # via mlflow
 docker==5.0.3
     # via mlflow
 ecs-logging==2.0.0
@@ -61,8 +58,6 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.41
     # via mlflow
-greenlet==3.0.1
-    # via sqlalchemy
 gunicorn==20.1.0
     # via mlflow
 idna==3.3
@@ -96,7 +91,7 @@ markupsafe==2.1.1
     #   werkzeug
 matplotlib==3.7.1
     # via mlflow
-mlflow==2.10.0
+mlflow==2.10.2
     # via -r requirements-mlflow.in
 multidict==6.0.2
     # via
@@ -111,8 +106,6 @@ numpy==1.23.5
     #   pyarrow
     #   scikit-learn
     #   scipy
-oauthlib==3.2.2
-    # via databricks-cli
 packaging==21.3
     # via
     #   matplotlib
@@ -131,8 +124,6 @@ pyarrow==14.0.1
     # via mlflow
 pycparser==2.21
     # via cffi
-pyjwt==2.4.0
-    # via databricks-cli
 pyparsing==3.0.9
     # via
     #   matplotlib
@@ -152,7 +143,6 @@ querystring-parser==1.2.4
     # via mlflow
 requests==2.31.0
     # via
-    #   databricks-cli
     #   docker
     #   mlflow
 s3transfer==0.6.0
@@ -167,7 +157,6 @@ scipy==1.10.0
     #   scikit-learn
 six==1.16.0
     # via
-    #   databricks-cli
     #   python-dateutil
     #   querystring-parser
 sklearn==0.0
@@ -180,8 +169,6 @@ sqlalchemy==1.4.39
     #   mlflow
 sqlparse==0.4.4
     # via mlflow
-tabulate==0.8.10
-    # via databricks-cli
 threadpoolctl==3.1.0
     # via scikit-learn
 urllib3==1.26.18


### PR DESCRIPTION
This is related to the version increase related to a vulnerability, but increasing patch versions later than that to just have the latest version right now while we're at it.