### PR TITLE
chore: run database migrations before start

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,9 @@ set -e
 (
     cd "$(dirname "$0")"
 
+    echo "Running migrations..."
+    mlflow db upgrade $DATABASE_URI
+
     echo "Starting mlflow server and proxy..."
     parallel --will-cite --line-buffer --jobs 2 --halt now,done=1 ::: \
         "mlflow server --host 0.0.0.0 --port 5000 --serve-artifacts --artifacts-destination s3://${ARTIFACT_BUCKET_NAME} --backend-store-uri ${DATABASE_URI} --gunicorn-opts '--log-level debug'" \


### PR DESCRIPTION
This is so we can painlessly update MLFlow

(For some reason this wasn't needed on staging - the recent versions upgraded fine without this. Have to admit I'm not sure why)