### PR TITLE
chore: carry on even if migrations fail

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
-set -e
-
 (
     cd "$(dirname "$0")"
 
     echo "Running migrations..."
     mlflow db upgrade $DATABASE_URI
+
+    # db upgrade only works without error strictly after the server has run at least once
+    # So we exit on failure only after we run db upgrade
+    set -e
 
     echo "Starting mlflow server and proxy..."
     parallel --will-cite --line-buffer --jobs 2 --halt now,done=1 ::: \


### PR DESCRIPTION
It looks like the "mlflow db upgrade" command expects tables to already exist, otherwise it fails with a "relation "metrics" does not exist" error.

However, we still want to run the upgrades later. So, we just march forward if migrations have failed. Not _that_ great, because it would be good for thing to error if they fail proper. However, for our case it's good enough.