### PR TITLE
fix: proxy startup error about HEAD being registered already

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -205,7 +205,6 @@ async def async_main():
                 for method in [
                     "delete",
                     "get",
-                    "head",
                     "options",
                     "patch",
                     "post",


### PR DESCRIPTION
If we register a GET handler, in recent aiohttp we no longeer need to register a HEAD handler, and in fact if we do both, we get the error:

> RuntimeError: Added route will never be executed, method HEAD is already registered

So this change fixes the error by just not registered a HEAD handler.